### PR TITLE
WIP on integ test for list job where previous job had completed

### DIFF
--- a/.github/workflows/multi-node-test.yml
+++ b/.github/workflows/multi-node-test.yml
@@ -1,0 +1,32 @@
+name: Integ tests with Security
+# This workflow is triggered on pull requests and pushes to main or an OpenSearch release branch
+on:
+  pull_request:
+    branches:
+      - "*"
+  push:
+    branches:
+      - "*"
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        java: [ 21 ]
+    # Job name
+    name: Build and test Job-scheduler
+    # This job runs on Linux
+    runs-on: ubuntu-latest
+    steps:
+      # This step uses the setup-java Github action: https://github.com/actions/setup-java
+      - name: Set Up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      # This step uses the checkout Github action: https://github.com/actions/checkout
+      - name: Checkout Branch
+        uses: actions/checkout@v4
+      - name: Run Job-scheduler Integ Tests with Security
+        run: |
+          echo "Running integ tests with multiple nodes..."
+          ./gradlew :integTest --tests "SampleJobRunnerRestMultiNodeIT" -DnumNodes=2

--- a/.github/workflows/multi-node-test.yml
+++ b/.github/workflows/multi-node-test.yml
@@ -26,7 +26,7 @@ jobs:
       # This step uses the checkout Github action: https://github.com/actions/checkout
       - name: Checkout Branch
         uses: actions/checkout@v4
-      - name: Run Job-scheduler Integ Tests with Security
+      - name: Run Job-scheduler Integ Tests with multiple nodes
         run: |
           echo "Running integ tests with multiple nodes..."
-          ./gradlew :integTest --tests "SampleJobRunnerRestMultiNodeIT" -DnumNodes=2
+          ./gradlew :opensearch-job-scheduler-sample-extension-plugin:integTest --tests "SampleJobRunnerRestMultiNodeIT" -DnumNodes=2

--- a/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleExtensionIntegTestCase.java
+++ b/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleExtensionIntegTestCase.java
@@ -333,7 +333,7 @@ public class SampleExtensionIntegTestCase extends OpenSearchRestTestCase {
     }
 
     protected void createTestIndex(String index) throws IOException {
-        createIndex(index, Settings.builder().put("index.number_of_shards", 2).put("index.number_of_replicas", 0).build());
+        createIndex(index, Settings.builder().put("index.number_of_shards", 1).put("index.auto_expand_replicas", "0-all").build());
     }
 
     protected void deleteTestIndex(String index) throws IOException {
@@ -378,7 +378,7 @@ public class SampleExtensionIntegTestCase extends OpenSearchRestTestCase {
                         createWatcherJob(jobId, jobParameter);
                         timer.cancel();
                         timer.purge();
-                        Response response = makeRequest(client(), "GET", SCHEDULER_INFO_URI, Map.of(), null);
+                        Response response = makeRequest(client(), "GET", SCHEDULER_INFO_URI + "?by_node", Map.of(), null);
                         Map<String, Object> responseJson = JsonXContent.jsonXContent.createParser(
                             NamedXContentRegistry.EMPTY,
                             LoggingDeprecationHandler.INSTANCE,

--- a/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleExtensionIntegTestCase.java
+++ b/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleExtensionIntegTestCase.java
@@ -62,6 +62,8 @@ import java.util.Optional;
 import java.util.Timer;
 import java.util.TimerTask;
 
+import static org.opensearch.jobscheduler.sampleextension.SampleJobRunnerRestIT.SCHEDULER_INFO_URI;
+
 public class SampleExtensionIntegTestCase extends OpenSearchRestTestCase {
 
     protected boolean isHttps() {
@@ -376,6 +378,13 @@ public class SampleExtensionIntegTestCase extends OpenSearchRestTestCase {
                         createWatcherJob(jobId, jobParameter);
                         timer.cancel();
                         timer.purge();
+                        Response response = makeRequest(client(), "GET", SCHEDULER_INFO_URI, Map.of(), null);
+                        Map<String, Object> responseJson = JsonXContent.jsonXContent.createParser(
+                            NamedXContentRegistry.EMPTY,
+                            LoggingDeprecationHandler.INSTANCE,
+                            response.getEntity().getContent()
+                        ).map();
+                        System.out.println("Response from list jobs before: " + responseJson);
                     }
                     if (timeoutCounter >= 24) {
                         timer.cancel();

--- a/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleExtensionIntegTestCase.java
+++ b/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleExtensionIntegTestCase.java
@@ -62,8 +62,6 @@ import java.util.Optional;
 import java.util.Timer;
 import java.util.TimerTask;
 
-import static org.opensearch.jobscheduler.sampleextension.SampleJobRunnerRestIT.SCHEDULER_INFO_URI;
-
 public class SampleExtensionIntegTestCase extends OpenSearchRestTestCase {
 
     protected boolean isHttps() {
@@ -378,13 +376,6 @@ public class SampleExtensionIntegTestCase extends OpenSearchRestTestCase {
                         createWatcherJob(jobId, jobParameter);
                         timer.cancel();
                         timer.purge();
-                        Response response = makeRequest(client(), "GET", SCHEDULER_INFO_URI + "?by_node", Map.of(), null);
-                        Map<String, Object> responseJson = JsonXContent.jsonXContent.createParser(
-                            NamedXContentRegistry.EMPTY,
-                            LoggingDeprecationHandler.INSTANCE,
-                            response.getEntity().getContent()
-                        ).map();
-                        System.out.println("Response from list jobs before: " + responseJson);
                     }
                     if (timeoutCounter >= 24) {
                         timer.cancel();

--- a/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunnerRestIT.java
+++ b/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunnerRestIT.java
@@ -14,6 +14,7 @@ import org.opensearch.common.xcontent.LoggingDeprecationHandler;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.jobscheduler.spi.schedule.IntervalSchedule;
+import org.opensearch.test.OpenSearchIntegTestCase;
 import org.opensearch.test.rest.OpenSearchRestTestCase;
 
 import java.io.IOException;
@@ -21,9 +22,10 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
 
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE, numDataNodes = 2)
 public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
 
-    private static final String SCHEDULER_INFO_URI = "/_plugins/_job_scheduler/api/jobs";
+    static final String SCHEDULER_INFO_URI = "/_plugins/_job_scheduler/api/jobs";
 
     public void testJobCreateWithCorrectParams() throws IOException {
         SampleJobParameter jobParameter = new SampleJobParameter();
@@ -126,7 +128,7 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
             LoggingDeprecationHandler.INSTANCE,
             response.getEntity().getContent()
         ).map();
-        System.out.println("Response from list jobs: " + responseJson);
+        System.out.println("Response from list jobs after: " + responseJson);
     }
 
     public void testAcquiredLockPreventExecOfTasks() throws Exception {

--- a/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunnerRestIT.java
+++ b/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunnerRestIT.java
@@ -123,20 +123,29 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
         String newIndex = createTestIndex();
         jobParameter.setIndexToWatch(newIndex);
 
+        Response response = makeRequest(client(), "GET", SCHEDULER_INFO_URI + "?by_node", Map.of(), null);
+        Map<String, Object> responseJson = JsonXContent.jsonXContent.createParser(
+            NamedXContentRegistry.EMPTY,
+            LoggingDeprecationHandler.INSTANCE,
+            response.getEntity().getContent()
+        ).map();
+        // TODO Assert response has 11 jobs before and after
+        System.out.println("Response from list jobs before: " + responseJson);
+
         // wait till the job runner runs for the first time after 1 min & inserts a record into the watched index & then update the job with
         // new params.
         waitAndCreateWatcherJob(schedJobParameter.getIndexToWatch(), jobId, jobParameter);
         long actualCount = waitAndCountRecords(newIndex, 130000);
 
         // Asserts that the job runner has the updated params & it inserted the record in the new watched index.
-        // Assert.assertEquals(1, actualCount);
+        Assert.assertEquals(1, actualCount);
         long prevIndexActualCount = waitAndCountRecords(index, 0);
 
         // Asserts that the job runner no longer updates the old index as the job params have been updated.
-        // Assert.assertEquals(1, prevIndexActualCount);
+        Assert.assertEquals(1, prevIndexActualCount);
 
-        Response response = makeRequest(client(), "GET", SCHEDULER_INFO_URI + "?by_node", Map.of(), null);
-        Map<String, Object> responseJson = JsonXContent.jsonXContent.createParser(
+        response = makeRequest(client(), "GET", SCHEDULER_INFO_URI + "?by_node", Map.of(), null);
+        responseJson = JsonXContent.jsonXContent.createParser(
             NamedXContentRegistry.EMPTY,
             LoggingDeprecationHandler.INSTANCE,
             response.getEntity().getContent()

--- a/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunnerRestIT.java
+++ b/sample-extension-plugin/src/test/java/org/opensearch/jobscheduler/sampleextension/SampleJobRunnerRestIT.java
@@ -102,6 +102,19 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
         jobParameter.setSchedule(new IntervalSchedule(Instant.now(), 1, ChronoUnit.MINUTES));
         jobParameter.setLockDurationSeconds(120L);
 
+        for (int i = 0; i < 10; i++) {
+            // Creates a new watcher job.
+            String indexN = createTestIndex();
+            SampleJobParameter jobParameterN = new SampleJobParameter();
+            jobParameterN.setJobName("sample-job-it" + i);
+            jobParameterN.setIndexToWatch(indexN);
+            jobParameterN.setSchedule(new IntervalSchedule(Instant.now(), 1, ChronoUnit.MINUTES));
+            jobParameterN.setLockDurationSeconds(120L);
+
+            String jobIdN = OpenSearchRestTestCase.randomAlphaOfLength(10);
+            createWatcherJob(jobIdN, jobParameterN);
+        }
+
         // Creates a new watcher job.
         String jobId = OpenSearchRestTestCase.randomAlphaOfLength(10);
         SampleJobParameter schedJobParameter = createWatcherJob(jobId, jobParameter);
@@ -116,13 +129,13 @@ public class SampleJobRunnerRestIT extends SampleExtensionIntegTestCase {
         long actualCount = waitAndCountRecords(newIndex, 130000);
 
         // Asserts that the job runner has the updated params & it inserted the record in the new watched index.
-        Assert.assertEquals(1, actualCount);
+        // Assert.assertEquals(1, actualCount);
         long prevIndexActualCount = waitAndCountRecords(index, 0);
 
         // Asserts that the job runner no longer updates the old index as the job params have been updated.
-        Assert.assertEquals(1, prevIndexActualCount);
+        // Assert.assertEquals(1, prevIndexActualCount);
 
-        Response response = makeRequest(client(), "GET", SCHEDULER_INFO_URI, Map.of(), null);
+        Response response = makeRequest(client(), "GET", SCHEDULER_INFO_URI + "?by_node", Map.of(), null);
         Map<String, Object> responseJson = JsonXContent.jsonXContent.createParser(
             NamedXContentRegistry.EMPTY,
             LoggingDeprecationHandler.INSTANCE,


### PR DESCRIPTION
### Description

Creates an integ test in sample plugin that calls List jobs API.

Example response: 

```
Response from list jobs: {total_jobs=1, failures=[], jobs=[{job_type=scheduler_sample_extension, enabled_time=2025-07-08T15:53:40.402Z, next_expected_execution_time=2025-07-08T15:55:40.402856Z, last_execution_time=2025-07-08T15:54:40.406225Z, enabled=true, last_update_time=2025-07-08T15:53:40.402Z, schedule={start_time=2025-07-08T15:53:40.402Z, unit=Minutes, interval=1, type=interval}, lock_duration=120, delay=none, jitter=none, job_id=irfepSkBEN, descheduled=false, name=sample-job-it, last_expected_execution_time=2025-07-08T15:54:40.402856Z, index_name=.scheduler_sample_extension}]}
```

The changes in this PR demonstrate the issue when there are multiple jobs:

```
java.lang.IllegalArgumentException: can not write type [class java.time.Instant]
	at org.opensearch.core.common.io.stream.StreamOutput.getWriter(StreamOutput.java:826) ~[opensearch-core-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
	at org.opensearch.core.common.io.stream.StreamOutput.writeGenericValue(StreamOutput.java:843) ~[opensearch-core-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
	at org.opensearch.core.common.io.stream.StreamOutput.lambda$static$12(StreamOutput.java:726) ~[opensearch-core-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
	at org.opensearch.core.common.io.stream.StreamOutput.writeGenericValue(StreamOutput.java:844) ~[opensearch-core-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
	at org.opensearch.core.common.io.stream.StreamOutput.lambda$static$10(StreamOutput.java:704) ~[opensearch-core-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
	at org.opensearch.core.common.io.stream.StreamOutput.writeGenericValue(StreamOutput.java:844) ~[opensearch-core-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
	at org.opensearch.core.common.io.stream.StreamOutput.lambda$static$12(StreamOutput.java:726) ~[opensearch-core-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
	at org.opensearch.core.common.io.stream.StreamOutput.writeGenericValue(StreamOutput.java:844) ~[opensearch-core-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
	at org.opensearch.core.common.io.stream.StreamOutput.writeMap(StreamOutput.java:578) ~[opensearch-core-3.2.0-SNAPSHOT.jar:3.2.0-SNAPSHOT]
	at org.opensearch.jobscheduler.transport.response.GetScheduledInfoNodeResponse.writeTo(GetScheduledInfoNodeResponse.java:47) ~[?:?]
```

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/job-scheduler/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
