### PR TITLE
Add standby mode to suppress Job Scheduler on follower clusters

### DIFF
--- a/src/main/java/org/opensearch/jobscheduler/JobSchedulerPlugin.java
+++ b/src/main/java/org/opensearch/jobscheduler/JobSchedulerPlugin.java
@@ -95,6 +95,7 @@ public class JobSchedulerPlugin extends Plugin implements ActionPlugin, Extensib
     public JobSchedulerPlugin() {
         this.indicesToListen = new HashSet<>();
         this.indexToJobProviders = new HashMap<>();
+        this.standbyModeEnabled = new AtomicBoolean(false);
     }
 
     public Set<String> getIndicesToListen() {

--- a/src/main/java/org/opensearch/jobscheduler/JobSchedulerPlugin.java
+++ b/src/main/java/org/opensearch/jobscheduler/JobSchedulerPlugin.java
@@ -72,6 +72,7 @@ import java.util.Set;
 import java.util.Collection;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
 public class JobSchedulerPlugin extends Plugin implements ActionPlugin, ExtensiblePlugin, SystemIndexPlugin, IdentityAwarePlugin {
@@ -89,6 +90,7 @@ public class JobSchedulerPlugin extends Plugin implements ActionPlugin, Extensib
     private PluginClient pluginClient;
 
     private JobDetailsService jobDetailsService;
+    private AtomicBoolean standbyModeEnabled;
 
     public JobSchedulerPlugin() {
         this.indicesToListen = new HashSet<>();
@@ -131,11 +133,13 @@ public class JobSchedulerPlugin extends Plugin implements ActionPlugin, Extensib
         Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
         Supplier<Boolean> statusHistoryEnabled = () -> JobSchedulerSettings.STATUS_HISTORY.get(environment.settings());
+        standbyModeEnabled = new AtomicBoolean(JobSchedulerSettings.STANDBY_MODE.get(environment.settings()));
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(JobSchedulerSettings.STANDBY_MODE, standbyModeEnabled::set);
         this.pluginClient = new PluginClient(client);
         this.historyService = new JobHistoryService(pluginClient, clusterService);
         this.lockService = new LockServiceImpl(pluginClient, clusterService, historyService, statusHistoryEnabled);
         this.jobDetailsService = new JobDetailsService(client, clusterService, this.indicesToListen, this.indexToJobProviders);
-        this.scheduler = new JobScheduler(threadPool, this.lockService);
+        this.scheduler = new JobScheduler(threadPool, this.lockService, standbyModeEnabled::get);
         this.sweeper = initSweeper(
             environment.settings(),
             client,
@@ -168,6 +172,7 @@ public class JobSchedulerPlugin extends Plugin implements ActionPlugin, Extensib
         settingList.add(JobSchedulerSettings.SWEEP_PERIOD);
         settingList.add(JobSchedulerSettings.JITTER_LIMIT);
         settingList.add(JobSchedulerSettings.STATUS_HISTORY);
+        settingList.add(JobSchedulerSettings.STANDBY_MODE);
         return settingList;
     }
 
@@ -268,8 +273,8 @@ public class JobSchedulerPlugin extends Plugin implements ActionPlugin, Extensib
         Supplier<DiscoveryNodes> nodesInCluster
     ) {
         RestGetJobDetailsAction restGetJobDetailsAction = new RestGetJobDetailsAction(jobDetailsService);
-        RestGetLockAction restGetLockAction = new RestGetLockAction(lockService);
-        RestReleaseLockAction restReleaseLockAction = new RestReleaseLockAction(lockService);
+        RestGetLockAction restGetLockAction = new RestGetLockAction(lockService, standbyModeEnabled::get);
+        RestReleaseLockAction restReleaseLockAction = new RestReleaseLockAction(lockService, standbyModeEnabled::get);
         RestGetScheduledInfoAction restGetScheduledInfoAction = new RestGetScheduledInfoAction();
         RestGetLocksAction restGetAllLocksAction = new RestGetLocksAction();
         return List.of(

--- a/src/main/java/org/opensearch/jobscheduler/JobSchedulerSettings.java
+++ b/src/main/java/org/opensearch/jobscheduler/JobSchedulerSettings.java
@@ -60,4 +60,11 @@ public class JobSchedulerSettings {
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
+
+    public static final Setting<Boolean> STANDBY_MODE = Setting.boolSetting(
+        "plugins.jobscheduler.standby_mode",
+        false,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
 }

--- a/src/main/java/org/opensearch/jobscheduler/rest/action/RestGetLockAction.java
+++ b/src/main/java/org/opensearch/jobscheduler/rest/action/RestGetLockAction.java
@@ -28,6 +28,7 @@ import org.opensearch.core.rest.RestStatus;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Supplier;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -45,11 +46,18 @@ import static org.opensearch.jobscheduler.spi.LockModel.GET_LOCK_ACTION;
  */
 public class RestGetLockAction extends BaseRestHandler {
     private final Logger logger = LogManager.getLogger(RestGetLockAction.class);
+    private static final String STANDBY_MODE_MESSAGE = "Job Scheduler lock mutation is read-only because this cluster is in standby mode.";
 
     public LockService lockService;
+    private final Supplier<Boolean> standbyModeEnabled;
 
     public RestGetLockAction(final LockService lockService) {
+        this(lockService, () -> false);
+    }
+
+    public RestGetLockAction(final LockService lockService, final Supplier<Boolean> standbyModeEnabled) {
         this.lockService = lockService;
+        this.standbyModeEnabled = standbyModeEnabled;
     }
 
     @Override
@@ -65,6 +73,10 @@ public class RestGetLockAction extends BaseRestHandler {
     @VisibleForTesting
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+        if (standbyModeEnabled.get()) {
+            return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.FORBIDDEN, STANDBY_MODE_MESSAGE));
+        }
+
         XContentParser parser = restRequest.contentParser();
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
 

--- a/src/main/java/org/opensearch/jobscheduler/rest/action/RestReleaseLockAction.java
+++ b/src/main/java/org/opensearch/jobscheduler/rest/action/RestReleaseLockAction.java
@@ -16,6 +16,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.core.action.ActionListener;
@@ -35,11 +36,18 @@ public class RestReleaseLockAction extends BaseRestHandler {
 
     public static final String RELEASE_LOCK_ACTION = "release_lock_action";
     private final Logger logger = LogManager.getLogger(RestReleaseLockAction.class);
+    private static final String STANDBY_MODE_MESSAGE = "Job Scheduler lock mutation is read-only because this cluster is in standby mode.";
 
     private LockService lockService;
+    private final Supplier<Boolean> standbyModeEnabled;
 
     public RestReleaseLockAction(LockService lockService) {
+        this(lockService, () -> false);
+    }
+
+    public RestReleaseLockAction(LockService lockService, Supplier<Boolean> standbyModeEnabled) {
         this.lockService = lockService;
+        this.standbyModeEnabled = standbyModeEnabled;
     }
 
     @Override
@@ -56,6 +64,10 @@ public class RestReleaseLockAction extends BaseRestHandler {
 
     @Override
     public RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient nodeClient) throws IOException {
+        if (standbyModeEnabled.get()) {
+            return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.FORBIDDEN, STANDBY_MODE_MESSAGE));
+        }
+
         String lockId = restRequest.param(LockModel.LOCK_ID);
         if (lockId == null || lockId.isEmpty()) {
             throw new IOException("lockId cannot be null or empty");

--- a/src/main/java/org/opensearch/jobscheduler/scheduler/JobScheduler.java
+++ b/src/main/java/org/opensearch/jobscheduler/scheduler/JobScheduler.java
@@ -28,8 +28,10 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 /**
  * Components that handles job scheduling/descheduling.
@@ -41,12 +43,18 @@ public class JobScheduler {
     private ScheduledJobInfo scheduledJobInfo;
     private Clock clock;
     private final LockService lockService;
+    private final Supplier<Boolean> standbyModeEnabled;
 
     public JobScheduler(ThreadPool threadPool, final LockService lockService) {
+        this(threadPool, lockService, () -> false);
+    }
+
+    public JobScheduler(ThreadPool threadPool, final LockService lockService, final Supplier<Boolean> standbyModeEnabled) {
         this.threadPool = threadPool;
         this.scheduledJobInfo = new ScheduledJobInfo();
         this.clock = Clock.systemDefaultZone();
         this.lockService = lockService;
+        this.standbyModeEnabled = standbyModeEnabled;
     }
 
     @VisibleForTesting
@@ -71,6 +79,10 @@ public class JobScheduler {
         JobDocVersion version,
         Double jitterLimit
     ) {
+        if (standbyModeEnabled.get()) {
+            log.debug("Job Scheduler standby mode is enabled, skipping scheduling job id {} for index {}.", docId, indexName);
+            return false;
+        }
         log.info("Scheduling job id {} for index {} .", docId, indexName);
         JobSchedulingInfo jobInfo;
         synchronized (this.scheduledJobInfo.getJobsByIndex(indexName)) {
@@ -127,6 +139,12 @@ public class JobScheduler {
         return true;
     }
 
+    public void descheduleAll() {
+        for (Map.Entry<String, Map<String, JobSchedulingInfo>> indexJobs : this.scheduledJobInfo.getJobInfoMap().entrySet()) {
+            this.bulkDeschedule(indexJobs.getKey(), new ArrayList<>(indexJobs.getValue().keySet()));
+        }
+    }
+
     @VisibleForTesting
     boolean reschedule(
         ScheduledJobParameter jobParameter,
@@ -135,6 +153,10 @@ public class JobScheduler {
         JobDocVersion version,
         Double jitterLimit
     ) {
+        if (standbyModeEnabled.get()) {
+            log.debug("Job Scheduler standby mode is enabled, skipping reschedule for job {}.", jobParameter.getName());
+            return false;
+        }
         if (jobParameter.getEnabledTime() == null) {
             log.info("There is no enable time of job {}, this job should never be scheduled.", jobParameter.getName());
             return false;

--- a/src/main/java/org/opensearch/jobscheduler/sweeper/JobSweeper.java
+++ b/src/main/java/org/opensearch/jobscheduler/sweeper/JobSweeper.java
@@ -96,6 +96,7 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
     private volatile Integer sweepSearchBackoffRetryCount;
     private volatile BackoffPolicy sweepSearchBackoff;
     private volatile Double jitterLimit;
+    private volatile boolean standbyMode;
 
     public JobSweeper(
         Settings settings,
@@ -132,6 +133,7 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
         this.sweepSearchBackoffMillis = JobSchedulerSettings.SWEEP_BACKOFF_MILLIS.get(settings);
         this.sweepSearchBackoffRetryCount = JobSchedulerSettings.SWEEP_BACKOFF_RETRY_COUNT.get(settings);
         this.jitterLimit = JobSchedulerSettings.JITTER_LIMIT.get(settings);
+        this.standbyMode = JobSchedulerSettings.STANDBY_MODE.get(settings);
         this.sweepSearchBackoff = this.updateRetryPolicy();
     }
 
@@ -163,14 +165,37 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
             this.jitterLimit = doubleValue;
             log.debug("Setting background sweep jitter limit: {}", this.jitterLimit);
         });
+        clusterService.getClusterSettings().addSettingsUpdateConsumer(JobSchedulerSettings.STANDBY_MODE, standbyModeEnabled -> {
+            this.standbyMode = standbyModeEnabled;
+            if (standbyModeEnabled) {
+                enterStandbyMode();
+            } else {
+                log.info("Job Scheduler standby mode disabled, reinitializing background sweep.");
+                initBackgroundSweep();
+            }
+        });
     }
 
     private BackoffPolicy updateRetryPolicy() {
         return BackoffPolicy.exponentialBackoff(this.sweepSearchBackoffMillis, this.sweepSearchBackoffRetryCount);
     }
 
+    private void enterStandbyMode() {
+        log.info("Job Scheduler standby mode enabled, cancelling background sweep and descheduling local jobs.");
+        if (this.scheduledFullSweep != null) {
+            this.scheduledFullSweep.cancel();
+            this.scheduledFullSweep = null;
+        }
+        this.scheduler.descheduleAll();
+        this.sweptJobs.clear();
+    }
+
     @Override
     public void afterStart() {
+        if (standbyMode) {
+            log.info("Job Scheduler standby mode enabled, background sweep will not start.");
+            return;
+        }
         this.initBackgroundSweep();
     }
 
@@ -188,6 +213,10 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
 
     @Override
     public void postIndex(ShardId shardId, Engine.Index index, Engine.IndexResult result) {
+        if (standbyMode) {
+            log.debug("Job Scheduler standby mode enabled, ignoring indexed job {} on index {}.", index.id(), shardId.getIndexName());
+            return;
+        }
         if (result.getResultType().equals(Engine.Result.Type.FAILURE)) {
             log.info("Indexing failed for job {} on index {}", index.id(), shardId.getIndexName());
             return;
@@ -210,6 +239,10 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
 
     @Override
     public void postDelete(ShardId shardId, Engine.Delete delete, Engine.DeleteResult result) {
+        if (standbyMode) {
+            log.debug("Job Scheduler standby mode enabled, ignoring deleted job {} on index {}.", delete.id(), shardId.getIndexName());
+            return;
+        }
         if (result.getResultType() == Engine.Result.Type.FAILURE) {
             ConcurrentHashMap<String, JobDocVersion> shardJobs = this.sweptJobs.containsKey(shardId)
                 ? this.sweptJobs.get(shardId)
@@ -234,6 +267,10 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
 
     @VisibleForTesting
     void sweep(ShardId shardId, String docId, BytesReference jobSource, JobDocVersion jobDocVersion) {
+        if (standbyMode) {
+            log.debug("Job Scheduler standby mode enabled, skipping sweep for job {} on index {}.", docId, shardId.getIndexName());
+            return;
+        }
         ConcurrentHashMap<String, JobDocVersion> jobVersionMap;
         if (this.sweptJobs.containsKey(shardId)) {
             jobVersionMap = this.sweptJobs.get(shardId);
@@ -281,6 +318,9 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
 
     @Override
     public void clusterChanged(ClusterChangedEvent event) {
+        if (standbyMode) {
+            return;
+        }
         for (String indexName : indexToProviders.keySet()) {
             if (event.indexRoutingTableChanged(indexName)) {
                 this.fullSweepExecutor.submit(() -> this.sweepIndex(indexName));
@@ -290,6 +330,10 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
 
     @VisibleForTesting
     void initBackgroundSweep() {
+        if (standbyMode) {
+            log.info("Job Scheduler standby mode enabled, skipping background sweep initialization.");
+            return;
+        }
         if (scheduledFullSweep != null) {
             this.scheduledFullSweep.cancel();
         }
@@ -333,6 +377,10 @@ public class JobSweeper extends LifecycleListener implements IndexingOperationLi
 
     @VisibleForTesting
     void sweepIndex(String indexName) {
+        if (standbyMode) {
+            log.debug("Job Scheduler standby mode enabled, skipping full sweep for index {}.", indexName);
+            return;
+        }
         ClusterState clusterState = this.clusterService.state();
         // checks to see if index no longer exists
         if (!clusterState.routingTable().hasIndex(indexName)) {

--- a/src/test/java/org/opensearch/jobscheduler/JobSchedulerPluginTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/JobSchedulerPluginTests.java
@@ -137,7 +137,7 @@ public class JobSchedulerPluginTests extends OpenSearchTestCase {
     public void testGetSettings_returnsSettingsList() {
         List<Setting<?>> settings = plugin.getSettings();
         assertNotNull(settings);
-        assertEquals(13, settings.size());
+        assertEquals(14, settings.size());
         assertTrue(settings.contains(LegacyOpenDistroJobSchedulerSettings.SWEEP_PAGE_SIZE));
         assertTrue(settings.contains(LegacyOpenDistroJobSchedulerSettings.REQUEST_TIMEOUT));
         assertTrue(settings.contains(LegacyOpenDistroJobSchedulerSettings.SWEEP_BACKOFF_MILLIS));
@@ -150,6 +150,8 @@ public class JobSchedulerPluginTests extends OpenSearchTestCase {
         assertTrue(settings.contains(JobSchedulerSettings.SWEEP_BACKOFF_RETRY_COUNT));
         assertTrue(settings.contains(JobSchedulerSettings.SWEEP_PERIOD));
         assertTrue(settings.contains(JobSchedulerSettings.JITTER_LIMIT));
+        assertTrue(settings.contains(JobSchedulerSettings.STATUS_HISTORY));
+        assertTrue(settings.contains(JobSchedulerSettings.STANDBY_MODE));
     }
 
     public void testOnIndexModule() {

--- a/src/test/java/org/opensearch/jobscheduler/JobSchedulerSettingsTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/JobSchedulerSettingsTests.java
@@ -55,7 +55,8 @@ public class JobSchedulerSettingsTests extends OpenSearchTestCase {
                     JobSchedulerSettings.SWEEP_BACKOFF_MILLIS,
                     JobSchedulerSettings.SWEEP_BACKOFF_RETRY_COUNT,
                     JobSchedulerSettings.SWEEP_PAGE_SIZE,
-                    JobSchedulerSettings.SWEEP_PERIOD
+                    JobSchedulerSettings.SWEEP_PERIOD,
+                    JobSchedulerSettings.STANDBY_MODE
                 )
             )
         );
@@ -72,6 +73,10 @@ public class JobSchedulerSettingsTests extends OpenSearchTestCase {
         Settings settings = Settings.builder().put("plugins.jobscheduler.request_timeout", "42s").build();
         assertEquals(JobSchedulerSettings.REQUEST_TIMEOUT.get(settings), TimeValue.timeValueSeconds(42));
         assertEquals(LegacyOpenDistroJobSchedulerSettings.REQUEST_TIMEOUT.get(settings), TimeValue.timeValueSeconds(10));
+    }
+
+    public void testStandbyModeDefaultsToFalse() {
+        assertFalse(JobSchedulerSettings.STANDBY_MODE.get(Settings.EMPTY));
     }
 
     public void testSettingsGetValueWithLegacyFallback() {

--- a/src/test/java/org/opensearch/jobscheduler/JobSchedulerStandbyModeRestIT.java
+++ b/src/test/java/org/opensearch/jobscheduler/JobSchedulerStandbyModeRestIT.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.jobscheduler;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+
+import java.util.Map;
+
+public class JobSchedulerStandbyModeRestIT extends ODFERestTestCase {
+
+    public void testStandbyModeBlocksLockMutationRestApi() throws Exception {
+        try {
+            setStandbyMode(true);
+
+            ResponseException standbyException = expectThrows(
+                ResponseException.class,
+                () -> TestHelpers.makeRequest(
+                    client(),
+                    "GET",
+                    TestHelpers.GET_LOCK_BASE_URI,
+                    Map.of(),
+                    TestHelpers.toHttpEntity(TestHelpers.generateAcquireLockRequestBody("standby-job-index", "standby-job-id")),
+                    null
+                )
+            );
+            assertEquals(403, standbyException.getResponse().getStatusLine().getStatusCode());
+
+            setStandbyMode(false);
+
+            Response response = TestHelpers.makeRequest(
+                client(),
+                "GET",
+                TestHelpers.GET_LOCK_BASE_URI,
+                Map.of(),
+                TestHelpers.toHttpEntity(TestHelpers.generateAcquireLockRequestBody("active-job-index", "active-job-id")),
+                null
+            );
+            assertEquals(200, response.getStatusLine().getStatusCode());
+        } finally {
+            clearStandbyMode();
+        }
+    }
+
+    private void setStandbyMode(boolean standbyMode) throws Exception {
+        Request request = new Request("PUT", "/_cluster/settings");
+        request.setJsonEntity("{\"transient\":{\"" + JobSchedulerSettings.STANDBY_MODE.getKey() + "\":" + standbyMode + "}}");
+        adminClient().performRequest(request);
+    }
+
+    private void clearStandbyMode() throws Exception {
+        Request request = new Request("PUT", "/_cluster/settings");
+        request.setJsonEntity("{\"transient\":{\"" + JobSchedulerSettings.STANDBY_MODE.getKey() + "\":null}}");
+        adminClient().performRequest(request);
+    }
+}

--- a/src/test/java/org/opensearch/jobscheduler/scheduler/JobSchedulerTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/scheduler/JobSchedulerTests.java
@@ -29,6 +29,7 @@ import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @RunWith(RandomizedRunner.class)
 @SuppressWarnings({ "rawtypes" })
@@ -87,6 +88,24 @@ public class JobSchedulerTests extends OpenSearchTestCase {
         Assert.assertFalse(scheduled);
     }
 
+    public void testSchedule_standbyMode() {
+        AtomicBoolean standbyModeEnabled = new AtomicBoolean(true);
+        this.scheduler = new JobScheduler(this.threadPool, null, standbyModeEnabled::get);
+        ScheduledJobParameter jobParameter = buildScheduledJobParameter(
+            "job-id",
+            "dummy job name",
+            Instant.now().minus(1, ChronoUnit.HOURS),
+            Instant.now(),
+            new CronSchedule("* * * * *", ZoneId.systemDefault()),
+            true
+        );
+
+        boolean scheduled = this.scheduler.schedule("index-name", "job-id", jobParameter, null, dummyVersion, jitterLimit);
+
+        Assert.assertFalse(scheduled);
+        Mockito.verify(this.threadPool, Mockito.never()).schedule(Mockito.any(), Mockito.any(), Mockito.anyString());
+    }
+
     public void testDeschedule_singleJob() {
         JobSchedulingInfo jobInfo = new JobSchedulingInfo("job-index", "job-id", null);
         Scheduler.ScheduledCancellable scheduledCancellable = Mockito.mock(Scheduler.ScheduledCancellable.class);
@@ -136,6 +155,26 @@ public class JobSchedulerTests extends OpenSearchTestCase {
 
     public void testDeschedule_noSuchJob() {
         Assert.assertTrue(this.scheduler.deschedule("index-name", "job-id"));
+    }
+
+    public void testDescheduleAll() {
+        JobSchedulingInfo jobInfo1 = new JobSchedulingInfo("index-name", "job-id-1", null);
+        Scheduler.ScheduledCancellable scheduledCancellable1 = Mockito.mock(Scheduler.ScheduledCancellable.class);
+        Mockito.when(scheduledCancellable1.cancel()).thenReturn(true);
+        jobInfo1.setScheduledCancellable(scheduledCancellable1);
+        this.scheduler.getScheduledJobInfo().addJob("index-name", "job-id-1", jobInfo1);
+
+        JobSchedulingInfo jobInfo2 = new JobSchedulingInfo("index-name", "job-id-2", null);
+        Scheduler.ScheduledCancellable scheduledCancellable2 = Mockito.mock(Scheduler.ScheduledCancellable.class);
+        Mockito.when(scheduledCancellable2.cancel()).thenReturn(true);
+        jobInfo2.setScheduledCancellable(scheduledCancellable2);
+        this.scheduler.getScheduledJobInfo().addJob("index-name", "job-id-2", jobInfo2);
+
+        this.scheduler.descheduleAll();
+
+        Assert.assertTrue(this.scheduler.getScheduledJobInfo().getJobsByIndex("index-name").isEmpty());
+        Mockito.verify(scheduledCancellable1).cancel();
+        Mockito.verify(scheduledCancellable2).cancel();
     }
 
     public void testReschedule_noEnableTime() {

--- a/src/test/java/org/opensearch/jobscheduler/sweeper/JobSweeperTests.java
+++ b/src/test/java/org/opensearch/jobscheduler/sweeper/JobSweeperTests.java
@@ -115,6 +115,7 @@ public class JobSweeperTests extends OpenSearchAllocationTestCase {
         settingSet.add(JobSchedulerSettings.SWEEP_BACKOFF_MILLIS);
         settingSet.add(JobSchedulerSettings.SWEEP_PAGE_SIZE);
         settingSet.add(JobSchedulerSettings.JITTER_LIMIT);
+        settingSet.add(JobSchedulerSettings.STANDBY_MODE);
 
         ClusterSettings clusterSettings = new ClusterSettings(this.settings, settingSet);
         ClusterService originClusterService = ClusterServiceUtils.createClusterService(this.threadPool, discoveryNode, clusterSettings);
@@ -137,9 +138,35 @@ public class JobSweeperTests extends OpenSearchAllocationTestCase {
         );
     }
 
+    private JobSweeper createSweeper(Settings settings) {
+        ScheduledJobProvider jobProvider = new ScheduledJobProvider("JOB_TYPE", "job-index-name", this.jobParser, this.jobRunner);
+        Map<String, ScheduledJobProvider> jobProviderMap = new HashMap<>();
+        jobProviderMap.put("index-name", jobProvider);
+
+        return new JobSweeper(
+            settings,
+            this.client,
+            this.clusterService,
+            this.threadPool,
+            xContentRegistry,
+            jobProviderMap,
+            scheduler,
+            new LockServiceImpl(client, clusterService),
+            jobDetailsService
+        );
+    }
+
     public void testAfterStart() {
         this.sweeper.afterStart();
         Mockito.verify(this.threadPool).scheduleWithFixedDelay(Mockito.any(), Mockito.any(), Mockito.anyString());
+    }
+
+    public void testAfterStartInStandbyMode() {
+        JobSweeper standbySweeper = createSweeper(Settings.builder().put(JobSchedulerSettings.STANDBY_MODE.getKey(), true).build());
+
+        standbySweeper.afterStart();
+
+        Mockito.verify(this.threadPool, Mockito.never()).scheduleWithFixedDelay(Mockito.any(), Mockito.any(), Mockito.anyString());
     }
 
     public void testInitBackgroundSweep() {
@@ -210,6 +237,19 @@ public class JobSweeperTests extends OpenSearchAllocationTestCase {
             .sweep(Mockito.any(), Mockito.anyString(), Mockito.any(BytesReference.class), Mockito.any(JobDocVersion.class));
     }
 
+    public void testPostIndexInStandbyMode() {
+        JobSweeper standbySweeper = createSweeper(Settings.builder().put(JobSchedulerSettings.STANDBY_MODE.getKey(), true).build());
+        ShardId shardId = new ShardId(new Index("index-name", IndexMetadata.INDEX_UUID_NA_VALUE), 1);
+        Engine.Index index = this.getIndexOperation();
+        Engine.IndexResult indexResult = new Engine.IndexResult(1L, 1L, 1L, true);
+
+        standbySweeper.postIndex(shardId, index, indexResult);
+
+        Mockito.verify(this.scheduler, Mockito.never())
+            .schedule(Mockito.anyString(), Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyDouble());
+        Mockito.verify(this.clusterService, Mockito.never()).localNode();
+    }
+
     public void testPostIndex_indexFailed() {
         ShardId shardId = new ShardId(new Index("index-name", IndexMetadata.INDEX_UUID_NA_VALUE), 1);
         Engine.Index index = this.getIndexOperation();
@@ -278,6 +318,16 @@ public class JobSweeperTests extends OpenSearchAllocationTestCase {
                 Mockito.any(JobDocVersion.class),
                 Mockito.any(Double.class)
             );
+    }
+
+    public void testSweepInStandbyMode() throws IOException {
+        JobSweeper standbySweeper = createSweeper(Settings.builder().put(JobSchedulerSettings.STANDBY_MODE.getKey(), true).build());
+        ShardId shardId = new ShardId(new Index("index-name", IndexMetadata.INDEX_UUID_NA_VALUE), 1);
+
+        standbySweeper.sweep(shardId, "id", this.getTestJsonSource(), new JobDocVersion(1L, 1L, 2L));
+
+        Mockito.verify(this.scheduler, Mockito.never())
+            .schedule(Mockito.anyString(), Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyDouble());
     }
 
     public void testSweepUsesSeqNoSort() throws IOException {


### PR DESCRIPTION
### Description
Adds a dynamic `plugins.jobscheduler.standby_mode` setting for CCR / DR follower clusters. When enabled, Job Scheduler stops local scheduling activity so replicated job documents can exist on a follower without running jobs there.

### Changes
- Adds dynamic `plugins.jobscheduler.standby_mode` setting.
- Suppresses scheduler `schedule` / `reschedule` while standby mode is enabled.
- Cancels background sweeps, deschedules local jobs, and clears swept-job state when standby mode is enabled.
- Makes sweeper entry points no-op in standby mode:
  - startup background sweep
  - index operation listeners
  - cluster change sweeps
  - full/index sweeps
- Blocks lock mutation REST APIs in standby mode (`_lock` and `_release_lock`) so standby clusters do not create/update local lock docs through those endpoints.
- Keeps read-only lock listing available.

### Why
For CCR-based DR, follower clusters may receive replicated job indices, but they should not execute scheduled jobs while acting as followers. Lock and history indices are local execution state, so standby mode prevents local execution paths from creating or mutating them.

### Testing
```
./gradlew compileJava compileTestJava
./gradlew :test --tests org.opensearch.jobscheduler.scheduler.JobSchedulerTests --tests org.opensearch.jobscheduler.sweeper.JobSweeperTests --tests org.opensearch.jobscheduler.JobSchedulerSettingsTests
./gradlew :integTest --tests org.opensearch.jobscheduler.JobSchedulerStandbyModeRestIT
git diff --check
```